### PR TITLE
Release v0.1.5-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 
 ---
 
+## [0.1.5-beta.1] - 2025-12-03
+
+### Ajouté
+- Affichage de la version actuelle de l'intégration dans les informations de l'appareil (remplace "Firmware: 1.0" par la version réelle)
+
+### Modifié
+- Mise à jour de la documentation des instructions Copilot pour refléter l'utilisation de PyPI pour Hydro-Quebec-API-Wrapper
+- Ajout de note sur la protection de la branche `main` dans le processus de release
+- Amélioration du formatage du fixture `mock_integration_version` dans les tests
+
+---
+
 ## [0.1.4-beta.1] - 2025-12-03
 
 ### Corrigé

--- a/custom_components/hydroqc/manifest.json
+++ b/custom_components/hydroqc/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hydroqc/hydroqc-ha/issues",
   "requirements": ["Hydro-Quebec-API-Wrapper==4.2.4"],
-  "version": "0.1.4-beta.1"
+  "version": "0.1.5-beta.1"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,26 @@ def statistics_metadata() -> dict[str, Any]:
 
 
 @pytest.fixture
+def mock_integration_version() -> Generator[AsyncMock]:
+    """Mock the integration version API for both sensor and binary_sensor."""
+    mock_integration = MagicMock()
+    mock_integration.version = "0.1.4-beta.1"
+
+    # Patch where it's imported (in sensor.py and binary_sensor.py)
+    with (
+        patch(
+            "custom_components.hydroqc.sensor.async_get_integration",
+            new=AsyncMock(return_value=mock_integration),
+        ) as mock_sensor,
+        patch(
+            "custom_components.hydroqc.binary_sensor.async_get_integration",
+            new=AsyncMock(return_value=mock_integration),
+        ),
+    ):
+        yield mock_sensor
+
+
+@pytest.fixture
 async def hass_with_recorder(hass: HomeAssistant) -> HomeAssistant:
     """Return a Home Assistant instance with recorder set up."""
     # The recorder component will be automatically set up by pytest-homeassistant

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -25,6 +25,7 @@ class TestHydroQcSensor:
         mock_config_entry: MockConfigEntry,
         mock_webuser: MagicMock,
         mock_contract: MagicMock,
+        mock_integration_version: MagicMock,
     ) -> None:
         """Test sensor setup for Rate D contract."""
         mock_config_entry.add_to_hass(hass)
@@ -68,6 +69,7 @@ class TestHydroQcSensor:
         mock_config_entry: MockConfigEntry,
         mock_webuser: MagicMock,
         mock_contract_dcpc: MagicMock,
+        mock_integration_version: MagicMock,
     ) -> None:
         """Test sensor setup for Rate D+CPC contract (winter credits)."""
         # Update config to use CPC rate option
@@ -111,6 +113,7 @@ class TestHydroQcSensor:
         mock_config_entry: MockConfigEntry,
         mock_webuser: MagicMock,
         mock_contract_dpc: MagicMock,
+        mock_integration_version: MagicMock,
     ) -> None:
         """Test sensor setup for Flex-D (DPC) contract."""
         # Update config to use DPC rate
@@ -154,6 +157,7 @@ class TestHydroQcSensor:
         mock_config_entry: MockConfigEntry,
         mock_webuser: MagicMock,
         mock_contract: MagicMock,
+        mock_integration_version: MagicMock,
     ) -> None:
         """Test sensor returns correct state value."""
         mock_config_entry.add_to_hass(hass)
@@ -196,6 +200,7 @@ class TestHydroQcSensor:
         mock_config_entry: MockConfigEntry,
         mock_webuser: MagicMock,
         mock_contract: MagicMock,
+        mock_integration_version: MagicMock,
     ) -> None:
         """Test sensor includes correct attributes."""
         mock_config_entry.add_to_hass(hass)
@@ -238,6 +243,7 @@ class TestHydroQcSensor:
         mock_config_entry: MockConfigEntry,
         mock_webuser: MagicMock,
         mock_contract: MagicMock,
+        mock_integration_version: MagicMock,
     ) -> None:
         """Test sensor availability based on data presence."""
         mock_config_entry.add_to_hass(hass)
@@ -272,6 +278,7 @@ class TestHydroQcSensor:
         mock_config_entry: MockConfigEntry,
         mock_webuser: MagicMock,
         mock_contract: MagicMock,
+        mock_integration_version: MagicMock,
     ) -> None:
         """Test sensor device info is correctly set."""
         mock_config_entry.add_to_hass(hass)
@@ -310,6 +317,7 @@ class TestHydroQcSensor:
         mock_config_entry: MockConfigEntry,
         mock_webuser: MagicMock,
         mock_contract: MagicMock,
+        mock_integration_version: MagicMock,
     ) -> None:
         """Test sensor unique IDs are correctly formatted."""
         mock_config_entry.add_to_hass(hass)


### PR DESCRIPTION
## Release v0.1.5-beta.1

### Ajouté
- Affichage de la version actuelle de l'intégration dans les informations de l'appareil (remplace "Firmware: 1.0" par la version réelle)

### Modifié
- Mise à jour de la documentation des instructions Copilot pour refléter l'utilisation de PyPI pour Hydro-Quebec-API-Wrapper
- Ajout de note sur la protection de la branche `main` dans le processus de release
- Amélioration du formatage du fixture `mock_integration_version` dans les tests

### Changes
- **sensor.py & binary_sensor.py**: Fetch version from manifest.json using `async_get_integration` from `homeassistant.loader`
- **tests/conftest.py**: Created `mock_integration_version` fixture with proper AsyncMock
- **tests/unit/test_sensor.py**: Added fixture to all 8 test functions
- **.github/copilot-instructions.md**: Updated external dependencies documentation and release process

### Test Results
- ✅ All 67 tests passing
- ✅ Ruff linting clean
- ✅ Mypy type checking clean (strict mode)
- ✅ Home Assistant starts without errors