### PR TITLE
Release v0.1.6-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@
 
 ---
 
+## [0.1.6-beta.1] - 2025-12-03
+
+### Corrigé
+- Correction des capteurs de préchauffage DCPC (Crédits hivernaux) qui se déclenchaient pour les pics non-critiques (#18, #20)
+  - Le capteur binaire `wc_pre_heat` ne retourne maintenant `True` que si le préchauffage est actif ET le prochain pic est critique
+  - Le capteur timestamp `wc_next_pre_heat_start` ne retourne maintenant l'horodatage que si le prochain pic est critique
+  - Les pics non-critiques (pics réguliers programmés) ne déclenchent plus d'alertes de préchauffage
+- Correction du mode OpenData qui retournait toujours des capteurs non disponibles
+  - Le coordinateur retourne maintenant correctement les données du `public_client` au lieu d'un dictionnaire vide
+  - Tous les capteurs du mode OpenData s'affichent maintenant correctement
+- Correction des capteurs et capteurs binaires pour supporter le mode OpenData
+  - Les champs `contract_name` et `contract_id` sont maintenant optionnels (mode OpenData utilise l'ID d'entrée de configuration)
+- Correction du fichier `services.yaml` pour utiliser le ciblage d'entité au lieu du ciblage d'appareil (non supporté)
+- Correction de la validation hassfest du manifest
+  - Ajout du champ requis `integration_type` (défini à `service`)
+  - Changement de `dependencies` à `after_dependencies` pour `recorder` (patron correct pour dépendance optionnelle)
+  - Tri alphabétique des clés du manifest (domaine, nom, puis alphabétique)
+- Correction de la validation HACS en ajoutant `ignore: brands` au workflow CI
+
+### Modifié
+- Mise à jour de Hydro-Quebec-API-Wrapper de 4.2.4 à 4.2.5
+- Changement de `integration_type` de `hub` à `service` (classification plus appropriée)
+
+### Ajouté
+- Ajout de tests complets pour le mode OpenData (14 nouveaux tests, total de 83 tests)
+  - Tests du coordinateur OpenData (8 tests): initialisation, récupération de données, gestion des erreurs
+  - Tests des capteurs OpenData (6 tests): création, valeurs d'état, attributs, disponibilité
+  - Fixtures pour tester les modes DPC et DCPC en OpenData
+  - Couverture de test pour le bug de retour de dictionnaire vide
+- Ajout de tests complets pour le filtrage du préchauffage par criticité (5 scénarios couverts)
+
+---
+
 ## [0.1.5-beta.1] - 2025-12-03
 
 ### Ajouté

--- a/custom_components/hydroqc/binary_sensor.py
+++ b/custom_components/hydroqc/binary_sensor.py
@@ -83,7 +83,8 @@ class HydroQcBinarySensor(CoordinatorEntity[HydroQcDataCoordinator], BinarySenso
         self._sensor_config = sensor_config
         self._data_source = sensor_config["data_source"]
 
-        contract_name = entry.data[CONF_CONTRACT_NAME]
+        # OpenData mode uses entry_id, Portal mode uses contract info
+        contract_name = entry.data.get(CONF_CONTRACT_NAME, "OpenData")
         contract_id = entry.data.get(CONF_CONTRACT_ID, entry.entry_id)
 
         # Entity configuration

--- a/custom_components/hydroqc/coordinator.py
+++ b/custom_components/hydroqc/coordinator.py
@@ -205,7 +205,7 @@ class HydroQcDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # If in peak-only mode, we're done
         if self.is_opendata_mode:
             _LOGGER.debug("OpenData mode: skipping portal data fetch")
-            return {}
+            return data
 
         # Portal mode: fetch contract data
         try:

--- a/custom_components/hydroqc/manifest.json
+++ b/custom_components/hydroqc/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hydroqc/hydroqc-ha/issues",
   "requirements": ["Hydro-Quebec-API-Wrapper==4.2.5"],
-  "version": "0.1.5-beta.1"
+  "version": "0.1.6-beta.1"
 }

--- a/custom_components/hydroqc/sensor.py
+++ b/custom_components/hydroqc/sensor.py
@@ -86,7 +86,8 @@ class HydroQcSensor(CoordinatorEntity[HydroQcDataCoordinator], SensorEntity):
         self._data_source = sensor_config["data_source"]
         self._attributes_sources = sensor_config.get("attributes", {})
 
-        contract_name = entry.data[CONF_CONTRACT_NAME]
+        # OpenData mode uses entry_id, Portal mode uses contract info
+        contract_name = entry.data.get(CONF_CONTRACT_NAME, "OpenData")
         contract_id = entry.data.get(CONF_CONTRACT_ID, entry.entry_id)
 
         # Entity configuration

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -404,10 +404,212 @@ class TestHydroQcDataCoordinator:
 
             # Test 1: Next peak is NON-critical - should return None
             mock_next_peak.is_critical = False
-            result = coordinator.get_sensor_value("public_client.peak_handler.next_peak.preheat.start_date")
+            result = coordinator.get_sensor_value(
+                "public_client.peak_handler.next_peak.preheat.start_date"
+            )
             assert result is None
 
             # Test 2: Next peak IS critical - should return timestamp
             mock_next_peak.is_critical = True
-            result = coordinator.get_sensor_value("public_client.peak_handler.next_peak.preheat.start_date")
+            result = coordinator.get_sensor_value(
+                "public_client.peak_handler.next_peak.preheat.start_date"
+            )
             assert result == preheat_start
+
+
+@pytest.mark.asyncio
+class TestHydroQcDataCoordinatorOpenData:
+    """Test the HydroQcDataCoordinator in OpenData mode."""
+
+    async def test_opendata_mode_initialization(
+        self, hass: HomeAssistant, mock_config_entry_opendata: MockConfigEntry
+    ) -> None:
+        """Test coordinator initializes correctly in OpenData mode."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.fetch_peak_data = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+
+            assert coordinator.name == DOMAIN
+            assert coordinator.is_opendata_mode is True
+            assert coordinator.rate == "DPC"
+            assert coordinator.rate_with_option == "DPC"
+
+    async def test_opendata_mode_returns_data_not_empty_dict(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata: MockConfigEntry,
+        mock_public_client: MagicMock,
+    ) -> None:
+        """Test OpenData mode returns data dict with public_client, not empty dict."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+            await coordinator.async_refresh()
+
+            # CRITICAL: This was the bug - was returning {} instead of data
+            assert coordinator.data is not None
+            assert "public_client" in coordinator.data
+            assert coordinator.data["public_client"] == mock_public_client
+            assert coordinator.last_update_success is True
+
+    async def test_opendata_mode_fetches_peak_data(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata: MockConfigEntry,
+        mock_public_client: MagicMock,
+    ) -> None:
+        """Test OpenData mode fetches peak data from API."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+            await coordinator.async_refresh()
+
+            # Should have called fetch_peak_data
+            mock_public_client.fetch_peak_data.assert_called_once()
+
+    async def test_opendata_mode_get_sensor_value(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata: MockConfigEntry,
+        mock_public_client: MagicMock,
+    ) -> None:
+        """Test get_sensor_value works in OpenData mode."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+            await coordinator.async_refresh()
+
+            # Test accessing public_client data
+            value = coordinator.get_sensor_value("public_client.peak_handler.current_state")
+            assert value == "normal"
+
+            value = coordinator.get_sensor_value("public_client.peak_handler.preheat_in_progress")
+            assert value is False
+
+    async def test_opendata_mode_dcpc_schedule_generation(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata_dcpc: MockConfigEntry,
+        mock_public_client_dcpc: MagicMock,
+    ) -> None:
+        """Test OpenData DCPC mode has generated schedule."""
+        mock_config_entry_opendata_dcpc.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client_dcpc,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata_dcpc)
+            await coordinator.async_refresh()
+
+            # Should have public_client with peak_handler
+            assert coordinator.data is not None
+            assert "public_client" in coordinator.data
+
+            # Check today's peaks exist (from generated schedule)
+            today_morning = coordinator.get_sensor_value(
+                "public_client.peak_handler.today_morning_peak"
+            )
+            today_evening = coordinator.get_sensor_value(
+                "public_client.peak_handler.today_evening_peak"
+            )
+
+            assert today_morning is not None
+            assert today_evening is not None
+            assert today_morning.is_critical is False  # Generated peaks are non-critical
+            assert today_evening.is_critical is False
+
+    async def test_opendata_mode_not_seasonal(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata: MockConfigEntry,
+        mock_public_client: MagicMock,
+    ) -> None:
+        """Test OpenData mode sensors are not seasonal (always available)."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+            await coordinator.async_refresh()
+
+            # OpenData mode sensors are never seasonal (always returns True)
+            assert coordinator.is_sensor_seasonal(
+                "public_client.peak_handler.current_state"
+            ) is True
+            assert coordinator.is_sensor_seasonal(
+                "public_client.peak_handler.preheat_in_progress"
+            ) is True
+
+    async def test_opendata_mode_api_error_handling(
+        self, hass: HomeAssistant, mock_config_entry_opendata: MockConfigEntry
+    ) -> None:
+        """Test OpenData mode handles API errors gracefully."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.fetch_peak_data = AsyncMock(side_effect=Exception("API failed"))
+            mock_client_class.return_value = mock_client
+
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+
+            # Should not raise, but log error
+            await coordinator.async_refresh()
+
+            # Data should still be set (with empty peak_handler)
+            assert coordinator.data is not None
+            assert "public_client" in coordinator.data
+
+    async def test_opendata_mode_no_portal_data_fetch(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata: MockConfigEntry,
+        mock_public_client: MagicMock,
+    ) -> None:
+        """Test OpenData mode does not attempt to fetch portal data."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with (
+            patch(
+                "custom_components.hydroqc.coordinator.PublicDataClient",
+                return_value=mock_public_client,
+            ),
+            patch("custom_components.hydroqc.coordinator.WebUser") as mock_webuser,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+            await coordinator.async_refresh()
+
+            # WebUser should never be instantiated in OpenData mode
+            mock_webuser.assert_not_called()
+
+            # Only public_client should have data (contract/account/customer are None)
+            assert coordinator.data is not None
+            assert "public_client" in coordinator.data
+            assert coordinator.data["public_client"] is not None
+            assert coordinator.data["contract"] is None
+            assert coordinator.data["account"] is None
+            assert coordinator.data["customer"] is None

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -347,3 +347,211 @@ class TestHydroQcSensor:
             assert len(unique_ids) == len(set(unique_ids))  # All unique
             for uid in unique_ids:
                 assert "test_contract_id" in uid
+
+
+@pytest.mark.asyncio
+class TestHydroQcSensorOpenData:
+    """Test the HydroQcSensor entities in OpenData mode."""
+
+    async def test_opendata_sensor_setup_dpc(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata: MockConfigEntry,
+        mock_public_client: MagicMock,
+        mock_integration_version: MagicMock,
+    ) -> None:
+        """Test sensor setup for OpenData DPC mode."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+            await coordinator.async_refresh()
+
+            # Register coordinator in hass.data like real integration does
+            hass.data.setdefault(DOMAIN, {})
+            hass.data[DOMAIN][mock_config_entry_opendata.entry_id] = coordinator
+
+            async_add_entities = MagicMock()
+            await async_setup_entry(hass, mock_config_entry_opendata, async_add_entities)
+
+            # Verify sensors were created
+            assert async_add_entities.called
+            entities = async_add_entities.call_args[0][0]
+
+            # OpenData DPC mode should have peak sensors
+            sensor_keys = [entity._sensor_key for entity in entities]
+            assert "dpc_state" in sensor_keys
+            assert "dpc_next_peak_start" in sensor_keys
+
+            # Should NOT have portal-specific sensors
+            assert "balance" not in sensor_keys
+            assert "current_billing_period_projected_bill" not in sensor_keys
+
+    async def test_opendata_sensor_setup_dcpc(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata_dcpc: MockConfigEntry,
+        mock_public_client_dcpc: MagicMock,
+        mock_integration_version: MagicMock,
+    ) -> None:
+        """Test sensor setup for OpenData DCPC mode."""
+        mock_config_entry_opendata_dcpc.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client_dcpc,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata_dcpc)
+            await coordinator.async_refresh()
+
+            # Register coordinator in hass.data like real integration does
+            hass.data.setdefault(DOMAIN, {})
+            hass.data[DOMAIN][mock_config_entry_opendata_dcpc.entry_id] = coordinator
+
+            async_add_entities = MagicMock()
+            await async_setup_entry(hass, mock_config_entry_opendata_dcpc, async_add_entities)
+
+            entities = async_add_entities.call_args[0][0]
+            sensor_keys = [entity._sensor_key for entity in entities]
+
+            # OpenData DCPC mode should have winter credit sensors
+            assert "wc_state" in sensor_keys
+            assert "wc_next_peak_start" in sensor_keys
+            assert "wc_next_anchor_start" in sensor_keys
+
+            # Should NOT have portal-specific sensors
+            assert "balance" not in sensor_keys
+            assert "wc_cumulated_credit" not in sensor_keys  # Only in Portal mode
+
+    async def test_opendata_sensor_state_value(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata: MockConfigEntry,
+        mock_public_client: MagicMock,
+        mock_integration_version: MagicMock,
+    ) -> None:
+        """Test OpenData sensor returns correct state value."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+            await coordinator.async_refresh()
+
+            # Register coordinator in hass.data like real integration does
+            hass.data.setdefault(DOMAIN, {})
+            hass.data[DOMAIN][mock_config_entry_opendata.entry_id] = coordinator
+
+            async_add_entities = MagicMock()
+            await async_setup_entry(hass, mock_config_entry_opendata, async_add_entities)
+
+            entities = async_add_entities.call_args[0][0]
+
+            # Find the current state sensor
+            state_sensor = next(
+                (e for e in entities if e._sensor_key == "dpc_state"),
+                None,
+            )
+            assert state_sensor is not None
+
+            # Verify it returns the correct value from coordinator
+            assert state_sensor.native_value == "normal"
+
+    async def test_opendata_sensor_attributes_data_source(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata: MockConfigEntry,
+        mock_public_client: MagicMock,
+        mock_integration_version: MagicMock,
+    ) -> None:
+        """Test OpenData sensor attributes include data_source=open_data."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+            await coordinator.async_refresh()
+
+            # Register coordinator in hass.data like real integration does
+            hass.data.setdefault(DOMAIN, {})
+            hass.data[DOMAIN][mock_config_entry_opendata.entry_id] = coordinator
+
+            async_add_entities = MagicMock()
+            await async_setup_entry(hass, mock_config_entry_opendata, async_add_entities)
+
+            entities = async_add_entities.call_args[0][0]
+
+            # Check that OpenData sensors have data_source="open_data"
+            for entity in entities:
+                extra_state_attributes = entity.extra_state_attributes
+                assert "data_source" in extra_state_attributes
+                assert extra_state_attributes["data_source"] == "open_data"
+
+    async def test_opendata_sensor_availability(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata: MockConfigEntry,
+        mock_public_client: MagicMock,
+        mock_integration_version: MagicMock,
+    ) -> None:
+        """Test OpenData sensor availability."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+            await coordinator.async_refresh()
+
+            # Register coordinator in hass.data like real integration does
+            hass.data.setdefault(DOMAIN, {})
+            hass.data[DOMAIN][mock_config_entry_opendata.entry_id] = coordinator
+
+            async_add_entities = MagicMock()
+            await async_setup_entry(hass, mock_config_entry_opendata, async_add_entities)
+
+            entities = async_add_entities.call_args[0][0]
+
+            # All OpenData sensors should be available
+            for entity in entities:
+                assert entity.available
+
+    async def test_opendata_sensor_unique_id_format(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_opendata: MockConfigEntry,
+        mock_public_client: MagicMock,
+        mock_integration_version: MagicMock,
+    ) -> None:
+        """Test OpenData sensor unique IDs use config entry ID."""
+        mock_config_entry_opendata.add_to_hass(hass)
+
+        with patch(
+            "custom_components.hydroqc.coordinator.PublicDataClient",
+            return_value=mock_public_client,
+        ):
+            coordinator = HydroQcDataCoordinator(hass, mock_config_entry_opendata)
+            await coordinator.async_refresh()
+
+            # Register coordinator in hass.data like real integration does
+            hass.data.setdefault(DOMAIN, {})
+            hass.data[DOMAIN][mock_config_entry_opendata.entry_id] = coordinator
+
+            async_add_entities = MagicMock()
+            await async_setup_entry(hass, mock_config_entry_opendata, async_add_entities)
+
+            entities = async_add_entities.call_args[0][0]
+
+            # Verify unique IDs are set and use entry_id as base
+            unique_ids = [entity.unique_id for entity in entities]
+            assert len(unique_ids) == len(set(unique_ids))  # All unique
+            # OpenData uses entry_id as contract_id (no contract_name field)
+            assert all(mock_config_entry_opendata.entry_id in uid for uid in unique_ids)


### PR DESCRIPTION
## Release v0.1.6-beta.1

### Corrigé
- **Correction des capteurs de préchauffage DCPC (Crédits hivernaux) qui se déclenchaient pour les pics non-critiques** (#18, #20)
  - Le capteur binaire `wc_pre_heat` ne retourne maintenant `True` que si le préchauffage est actif ET le prochain pic est critique
  - Le capteur timestamp `wc_next_pre_heat_start` ne retourne maintenant l'horodatage que si le prochain pic est critique
  - Les pics non-critiques (pics réguliers programmés) ne déclenchent plus d'alertes de préchauffage

- **Correction du mode OpenData qui retournait toujours des capteurs non disponibles**
  - Le coordinateur retourne maintenant correctement les données du `public_client` au lieu d'un dictionnaire vide
  - Tous les capteurs du mode OpenData s'affichent maintenant correctement

- **Correction des capteurs et capteurs binaires pour supporter le mode OpenData**
  - Les champs `contract_name` et `contract_id` sont maintenant optionnels (mode OpenData utilise l'ID d'entrée de configuration)

- Correction du fichier `services.yaml` pour utiliser le ciblage d'entité au lieu du ciblage d'appareil (non supporté)

- **Correction de la validation hassfest du manifest**
  - Ajout du champ requis `integration_type` (défini à `service`)
  - Changement de `dependencies` à `after_dependencies` pour `recorder` (patron correct pour dépendance optionnelle)
  - Tri alphabétique des clés du manifest (domaine, nom, puis alphabétique)

- Correction de la validation HACS en ajoutant `ignore: brands` au workflow CI

### Modifié
- Mise à jour de Hydro-Quebec-API-Wrapper de 4.2.4 à 4.2.5
- Changement de `integration_type` de `hub` à `service` (classification plus appropriée)

### Ajouté
- **Ajout de tests complets pour le mode OpenData (14 nouveaux tests, total de 83 tests)**
  - Tests du coordinateur OpenData (8 tests): initialisation, récupération de données, gestion des erreurs
  - Tests des capteurs OpenData (6 tests): création, valeurs d'état, attributs, disponibilité
  - Fixtures pour tester les modes DPC et DCPC en OpenData
  - Couverture de test pour le bug de retour de dictionnaire vide
- Ajout de tests complets pour le filtrage du préchauffage par criticité (5 scénarios couverts)

---

### Testing
- ✅ 83 tests passing (14 new OpenData tests added)
- ✅ All CI checks passing (ruff, mypy, pytest, hassfest, HACS)
- ✅ OpenData mode tested with DPC and DCPC rates
- ✅ DCPC preheat criticality filtering validated

### Closes
- Closes #18
- Closes #20