### PR TITLE
ci: remove brands ignore from HACS validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,6 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
-          ignore: brands
 
   validate-hassfest:
     name: Hassfest Validation


### PR DESCRIPTION
## Description

Remove the `ignore: brands` parameter from HACS validation in the CI workflow to ensure proper validation of brand icons and integration with the Home Assistant brands repository.

## Dependencies

⚠️ **Blocked by**: https://github.com/home-assistant/brands/pull/8621

This PR depends on the brands repository PR being merged first. The brands PR adds the Hydro-Québec integration icons to the Home Assistant brands repository.

**Do not merge this PR until the brands PR is merged.**

## Changes

- Removed `ignore: brands` from HACS validation step in `.github/workflows/ci.yml`

## Why

This allows HACS to properly validate that the integration follows Home Assistant branding requirements, including icon specifications and brand repository compliance. Currently, we skip this validation with `ignore: brands`, but once our icons are in the brands repository, we should validate properly.

## Testing

- [x] Wait for brands PR to be merged
- [x] CI checks pass without the ignore flag
- [x] HACS validation completes successfully