### PR TITLE
Release v0.1.7-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 ---
 
+## [0.1.7-beta.1] - 2025-12-05
+
+### Modifié
+- Mise à jour de Hydro-Quebec-API-Wrapper à 4.2.5 avec dépendances assouplies pour compatibilité Home Assistant
+
+---
+
 ## [0.1.6-beta.1] - 2025-12-03
 
 ### Corrigé

--- a/custom_components/hydroqc/manifest.json
+++ b/custom_components/hydroqc/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hydroqc/hydroqc-ha/issues",
   "requirements": ["Hydro-Quebec-API-Wrapper==4.2.5"],
-  "version": "0.1.6-beta.1"
+  "version": "0.1.7-beta.1"
 }


### PR DESCRIPTION
## Release v0.1.7-beta.1

Patch release to update dependency.

### Changes

- **Dependency Update**: Hydro-Quebec-API-Wrapper 4.2.5
  - Upstream library loosened its dependencies to match Home Assistant constraints
  - Integration maintains pinned version for stability

### Files Modified

- `CHANGELOG.md`: Added release notes for 0.1.7-beta.1
- `custom_components/hydroqc/manifest.json`: Bumped version to 0.1.7-beta.1

### Merge Instructions

Once CI passes and approved:
1. Merge this PR to main
2. Create and push git tag: `git tag -a v0.1.7-beta.1 -m "Release v0.1.7-beta.1"`
3. GitHub Actions will automatically create the release with hydroqc.zip