### PR TITLE
chore(ci): add HACS validation workflow with daily schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,24 +57,3 @@ jobs:
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
-
-  hacs:
-    name: HACS Validation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: HACS Validation
-        uses: hacs/action@main
-        with:
-          category: integration
-          ignore: brands
-  
-  hassfest:
-    name: Hassfest Validation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Hassfest Validation
-        uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,34 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate-hacs:
+    name: HACS Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+          ignore: brands
+
+  validate-hassfest:
+    name: Hassfest Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master


### PR DESCRIPTION
## Description

Adds a dedicated validation workflow following [HACS official recommendations](https://hacs.xyz/docs/publish/action/).

## Changes

- **New `validate.yml` workflow**:
  - Runs on pull requests (PR validation)
  - Runs daily at midnight (catch breaking changes)
  - Manual trigger capability via `workflow_dispatch`
  - Includes HACS validation (integration category, ignoring brands)
  - Includes Hassfest validation (HA structure validation)

- **Updated `ci.yml` workflow**:
  - Removed duplicate HACS and Hassfest jobs
  - Focused on code quality (lint, format, type check) and tests only
  - Cleaner separation of concerns

## Benefits

- ✅ Daily validation catches breaking changes in HACS or Home Assistant
- ✅ Manual trigger capability for on-demand validation
- ✅ Cleaner CI workflow structure
- ✅ Follows HACS best practices
- ✅ No redundant validations on PRs

## Testing

The validate workflow will run automatically on this PR to verify it works correctly.