### PR TITLE
Amélioration des messages d'erreur quand le site plante

### DIFF
--- a/custom_components/hydroqc/coordinator.py
+++ b/custom_components/hydroqc/coordinator.py
@@ -283,14 +283,14 @@ class HydroQcDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._last_peak_update_hour = current_hour
                 _LOGGER.info("[OpenData] Hourly peak data refresh at %02d:00", current_hour)
             except Exception as err:
-                _LOGGER.warning("[OpenData] Failed to fetch public peak data: %s", err, exc_info=True)
+                _LOGGER.warning("[OpenData] Failed to fetch public peak data: %s", err)
         else:
             # Still fetch but don't log as prominently (regular interval update)
             try:
                 await self.public_client.fetch_peak_data()
                 _LOGGER.debug("[OpenData] Public peak data fetched successfully")
             except Exception as err:
-                _LOGGER.warning("[OpenData] Failed to fetch public peak data: %s", err, exc_info=True)
+                _LOGGER.warning("[OpenData] Failed to fetch public peak data: %s", err)
 
         # Sync calendar events if configured and peak data available (for both modes)
         # Only start sync if not already running (prevent duplicate event creation)
@@ -361,10 +361,10 @@ class HydroQcDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 _LOGGER.debug("Successfully fetched authenticated contract data")
 
         except hydroqc.error.HydroQcHTTPError as err:
-            _LOGGER.error("HTTP error fetching Hydro-Québec data: %s", err, exc_info=True)
+            _LOGGER.error("HTTP error fetching Hydro-Québec data: %s", err)
             raise UpdateFailed(f"Error fetching Hydro-Québec data: {err}") from err
         except Exception as err:
-            _LOGGER.error("Unexpected error fetching data: %s", err, exc_info=True)
+            _LOGGER.error("Unexpected error fetching data: %s", err)
             raise UpdateFailed(f"Unexpected error: {err}") from err
 
         # Update timestamp on successful update


### PR DESCRIPTION
Donne la source de l'erreur dans les logs:

hydroqc.error.HydroQcHTTPError: Error Fetching https://services-cl.solutions.hydroquebec.com/lsw/portail/fr/group/clientele/portrait-de-consommation/resourceObtenirDonneesPeriodesConsommation - 400