### PR TITLE
docs: add critical update note to v0.3.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
 
 ## [0.3.0] - 2025-12-10
 
+### Note
+
+Ce projet est toujours en phase de développement initial et en constante évolution. Assurez-vous de vérifier les mises à jour fréquemment afin d'obtenir les dernières fonctionnalités et corrections.
+
+- Cette version contient un fix important pour les mise à jour de pointes non-critiques vers critiques dans le calendrier. **⚠️Lors de la prochaine pointe critique, assurez-vous que l'événement calendrier est mis à jour correctement.⚠️**
+- Assurez-vous de réimporter vos blueprints
+
+**Merci de signaler tout problème via les issues GitHub.**
+
 ### Modifié
 - Refactorisation complète du code en structure modulaire pour améliorer la maintenabilité
   - **coordinator/** : Division en modules (base, calendar_sync, consumption_sync, sensor_data)


### PR DESCRIPTION
## Description

Adds a critical user-facing note to the v0.3.0 changelog entry at the top of the release section.

## Changes

- Added **Note** section to v0.3.0 changelog explaining:
  - Project is in active development with frequent updates
  - Important fix for non-critical to critical peak calendar updates
  - ⚠️ Users should verify calendar event updates during next critical peak
  - Blueprints need to be reimported
  - Encourages issue reporting on GitHub

## Context

This note provides essential information to users about the calendar update fix included in v0.3.0 and actions they should take after upgrading.

## Related

Supersedes PR #61