### PR TITLE
feat(blueprints): Add separate AM/PM preheat timing and actions

### DIFF
--- a/blueprints/flex-d-calendar.yaml
+++ b/blueprints/flex-d-calendar.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     ### Période de pré-chauffage
 
-    Définissez combien de temps avant le début de l'événement vous souhaitez commencer le pré-chauffage de votre résidence (en minutes).
+    Définissez combien de temps avant le début de chaque pointe (matin et soir) vous souhaitez commencer le pré-chauffage de votre résidence. Vous pouvez configurer des délais différents pour le matin et le soir selon vos besoins de chauffage.
 
     ### Actions
 
@@ -60,9 +60,16 @@ blueprint:
         entity:
           domain: calendar
           multiple: false
-    preheat_offset:
-      name: Délai de pré-chauffage
-      description: "Temps avant le début de l'événement pour commencer le pré-chauffage (format -HH:MM:SS, ex: -02:00:00 pour 2 heures avant, -01:30:00 pour 1h30 avant)"
+    preheat_offset_morning:
+      name: Délai de pré-chauffage (matin)
+      description: "Temps avant le début de la pointe du matin pour commencer le pré-chauffage (format -HH:MM:SS, ex: -02:00:00 pour 2 heures avant, -01:30:00 pour 1h30 avant)"
+      default: "-02:00:00"
+      selector:
+        text:
+          type: text
+    preheat_offset_evening:
+      name: Délai de pré-chauffage (soir)
+      description: "Temps avant le début de la pointe du soir pour commencer le pré-chauffage (format -HH:MM:SS, ex: -02:00:00 pour 2 heures avant, -01:30:00 pour 1h30 avant)"
       default: "-02:00:00"
       selector:
         text:
@@ -76,16 +83,28 @@ blueprint:
           type: text
     
     # ===== ACTIONS =====
-    pre_heat_start_action:
-      name: Action de pré-chauffage
-      description: Actions à effectuer avant la période de pointe critique pour
+    pre_heat_start_morning_action:
+      name: Action de pré-chauffage (matin)
+      description: Actions à effectuer avant la période de pointe critique du matin pour
         pré-chauffer votre résidence.
       default:
         - parallel:
             - action: persistent_notification.create
               data:
-                title: "🔥 Pré-chauffage Flex-D"
-                message: "Début du pré-chauffage avant pointe critique. Augmentez le chauffage maintenant."
+                title: "🔥 Pré-chauffage Flex-D (matin)"
+                message: "Début du pré-chauffage avant pointe critique du matin. Augmentez le chauffage maintenant."
+      selector:
+        action: {}
+    pre_heat_start_evening_action:
+      name: Action de pré-chauffage (soir)
+      description: Actions à effectuer avant la période de pointe critique du soir pour
+        pré-chauffer votre résidence.
+      default:
+        - parallel:
+            - action: persistent_notification.create
+              data:
+                title: "🔥 Pré-chauffage Flex-D (soir)"
+                message: "Début du pré-chauffage avant pointe critique du soir. Augmentez le chauffage maintenant."
       selector:
         action: {}
     critical_peak_start_action:
@@ -121,11 +140,18 @@ blueprint:
   source_url: https://github.com/hydroqc/hydroqc-ha/blob/main/blueprints/flex-d-calendar.yaml
 mode: parallel
 trigger:
+  # Pre-heat start morning: configurable offset before morning peak
   - platform: calendar
     entity_id: !input hydroqc_calendar
     event: start
-    offset: !input preheat_offset
-    id: pre_heat_trigger
+    offset: !input preheat_offset_morning
+    id: pre_heat_morning_trigger
+  # Pre-heat start evening: configurable offset before evening peak
+  - platform: calendar
+    entity_id: !input hydroqc_calendar
+    event: start
+    offset: !input preheat_offset_evening
+    id: pre_heat_evening_trigger
   # Critical peak start: configurable offset before official peak start (default 1min before)
   - platform: calendar
     entity_id: !input hydroqc_calendar
@@ -144,12 +170,24 @@ condition:
     value_template: "{{ 'Tarif: DPC' in trigger.calendar_event.description }}"
 action:
   - choose:
+      # Pre-heat morning - CRITICAL ONLY
       - conditions:
           - condition: trigger
-            id: pre_heat_trigger
+            id: pre_heat_morning_trigger
+          - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int < 12 }}"
           - condition: template
             value_template: "{{ 'Critique: Oui' in trigger.calendar_event.description }}"
-        sequence: !input pre_heat_start_action
+        sequence: !input pre_heat_start_morning_action
+      # Pre-heat evening - CRITICAL ONLY
+      - conditions:
+          - condition: trigger
+            id: pre_heat_evening_trigger
+          - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int >= 12 }}"
+          - condition: template
+            value_template: "{{ 'Critique: Oui' in trigger.calendar_event.description }}"
+        sequence: !input pre_heat_start_evening_action
       - conditions:
           - condition: trigger
             id: peak_start_trigger

--- a/blueprints/winter-credits-calendar.yaml
+++ b/blueprints/winter-credits-calendar.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     ### Période de pré-chauffage
 
-    Définissez combien de temps avant le début de l'événement vous souhaitez commencer le pré-chauffage de votre résidence (en minutes).
+    Définissez combien de temps avant le début de chaque pointe (matin et soir) vous souhaitez commencer le pré-chauffage de votre résidence. Vous pouvez configurer des délais différents pour le matin et le soir selon vos besoins de chauffage.
 
     ### Périodes d'ancrage
     Les périodes d'ancrage sont des périodes de notification avant les pointes :
@@ -68,9 +68,16 @@ blueprint:
         entity:
           domain: calendar
           multiple: false
-    preheat_offset:
-      name: Délai de pré-chauffage
-      description: "Temps avant le début de l'événement pour commencer le pré-chauffage (format -HH:MM:SS, ex: -02:00:00 pour 2 heures avant, -01:30:00 pour 1h30 avant)"
+    preheat_offset_morning:
+      name: Délai de pré-chauffage (matin)
+      description: "Temps avant le début de la pointe du matin (6h) pour commencer le pré-chauffage (format -HH:MM:SS, ex: -02:00:00 pour 2 heures avant, -01:30:00 pour 1h30 avant)"
+      default: "-01:45:00"
+      selector:
+        text:
+          type: text
+    preheat_offset_evening:
+      name: Délai de pré-chauffage (soir)
+      description: "Temps avant le début de la pointe du soir (16h) pour commencer le pré-chauffage (format -HH:MM:SS, ex: -02:00:00 pour 2 heures avant, -01:30:00 pour 1h30 avant)"
       default: "-01:45:00"
       selector:
         text:
@@ -85,15 +92,26 @@ blueprint:
     
     # ===== ACTIONS ESSENTIELLES =====
     # Actions pour les pointes CRITIQUES (prioritaires)
-    critical_pre_heat_start_action:
-      name: "[Critique] Action pré-chauffage"
-      description: 'Actions pour pointes CRITIQUES - avant pointe (défaut 2h). Ex: Maximisez chauffage pour atteindre température élevée.'
+    critical_pre_heat_start_morning_action:
+      name: "[Critique] Action pré-chauffage (matin)"
+      description: 'Actions pour pointes CRITIQUES du matin - avant pointe. Ex: Maximisez chauffage pour atteindre température élevée.'
       default:
         - parallel:
             - action: persistent_notification.create
               data:
-                title: "🔥 Pré-chauffage Crédits hivernaux"
-                message: "Début du pré-chauffage avant pointe critique. Augmentez le chauffage maintenant."
+                title: "🔥 Pré-chauffage Crédits hivernaux (matin)"
+                message: "Début du pré-chauffage avant pointe critique du matin. Augmentez le chauffage maintenant."
+      selector:
+        action: {}
+    critical_pre_heat_start_evening_action:
+      name: "[Critique] Action pré-chauffage (soir)"
+      description: 'Actions pour pointes CRITIQUES du soir - avant pointe. Ex: Maximisez chauffage pour atteindre température élevée.'
+      default:
+        - parallel:
+            - action: persistent_notification.create
+              data:
+                title: "🔥 Pré-chauffage Crédits hivernaux (soir)"
+                message: "Début du pré-chauffage avant pointe critique du soir. Augmentez le chauffage maintenant."
       selector:
         action: {}
     critical_peak_start_action:
@@ -233,12 +251,18 @@ trigger:
     event: start
     offset: "-2:00:00"
     id: anchor_end_evening_trigger
-  # Pre-heat start: configurable offset before peak
+  # Pre-heat start morning: configurable offset before morning peak
   - platform: calendar
     entity_id: !input hydroqc_calendar
     event: start
-    offset: !input preheat_offset
-    id: pre_heat_trigger
+    offset: !input preheat_offset_morning
+    id: pre_heat_morning_trigger
+  # Pre-heat start evening: configurable offset before evening peak
+  - platform: calendar
+    entity_id: !input hydroqc_calendar
+    event: start
+    offset: !input preheat_offset_evening
+    id: pre_heat_evening_trigger
   # Critical peak start: configurable offset before official peak start (default 1min before)
   - platform: calendar
     entity_id: !input hydroqc_calendar
@@ -268,12 +292,16 @@ action:
           - condition: trigger
             id: anchor_start_morning_trigger
           - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int < 12 }}"
+          - condition: template
             value_template: "{{ 'Critique: Oui' in trigger.calendar_event.description }}"
         sequence: !input critical_anchor_start_morning_action
       # Morning anchor start - REGULAR
       - conditions:
           - condition: trigger
             id: anchor_start_morning_trigger
+          - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int < 12 }}"
           - condition: template
             value_template: "{{ 'Critique: Non' in trigger.calendar_event.description }}"
         sequence: !input regular_anchor_start_morning_action
@@ -283,12 +311,16 @@ action:
           - condition: trigger
             id: anchor_start_evening_trigger
           - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int >= 12 }}"
+          - condition: template
             value_template: "{{ 'Critique: Oui' in trigger.calendar_event.description }}"
         sequence: !input critical_anchor_start_evening_action
       # Evening anchor start - REGULAR
       - conditions:
           - condition: trigger
             id: anchor_start_evening_trigger
+          - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int >= 12 }}"
           - condition: template
             value_template: "{{ 'Critique: Non' in trigger.calendar_event.description }}"
         sequence: !input regular_anchor_start_evening_action
@@ -298,12 +330,16 @@ action:
           - condition: trigger
             id: anchor_end_morning_trigger
           - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int < 12 }}"
+          - condition: template
             value_template: "{{ 'Critique: Oui' in trigger.calendar_event.description }}"
         sequence: !input critical_anchor_end_morning_action
       # Morning anchor end - REGULAR
       - conditions:
           - condition: trigger
             id: anchor_end_morning_trigger
+          - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int < 12 }}"
           - condition: template
             value_template: "{{ 'Critique: Non' in trigger.calendar_event.description }}"
         sequence: !input regular_anchor_end_morning_action
@@ -313,6 +349,8 @@ action:
           - condition: trigger
             id: anchor_end_evening_trigger
           - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int >= 12 }}"
+          - condition: template
             value_template: "{{ 'Critique: Oui' in trigger.calendar_event.description }}"
         sequence: !input critical_anchor_end_evening_action
       # Evening anchor end - REGULAR
@@ -320,16 +358,29 @@ action:
           - condition: trigger
             id: anchor_end_evening_trigger
           - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int >= 12 }}"
+          - condition: template
             value_template: "{{ 'Critique: Non' in trigger.calendar_event.description }}"
         sequence: !input regular_anchor_end_evening_action
       
-      # Pre-heat - CRITICAL ONLY (regular peaks don't have preheat)
+      # Pre-heat morning - CRITICAL ONLY (regular peaks don't have preheat)
       - conditions:
           - condition: trigger
-            id: pre_heat_trigger
+            id: pre_heat_morning_trigger
+          - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int < 12 }}"
           - condition: template
             value_template: "{{ 'Critique: Oui' in trigger.calendar_event.description }}"
-        sequence: !input critical_pre_heat_start_action
+        sequence: !input critical_pre_heat_start_morning_action
+      # Pre-heat evening - CRITICAL ONLY (regular peaks don't have preheat)
+      - conditions:
+          - condition: trigger
+            id: pre_heat_evening_trigger
+          - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int >= 12 }}"
+          - condition: template
+            value_template: "{{ 'Critique: Oui' in trigger.calendar_event.description }}"
+        sequence: !input critical_pre_heat_start_evening_action
       
       # Peak start - CRITICAL (with offset before official start)
       - conditions:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./.ha-test-config:/config
       - ./custom_components/hydroqc:/config/custom_components/hydroqc:ro
+      - ./blueprints:/config/blueprints/automation/hydroqc:ro
       - /etc/localtime:/etc/localtime:ro
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Description

Enhances both Winter Credits and Flex-D blueprints with separate AM/PM preheat configuration for maximum flexibility when responding to critical peak events.

## Changes

### Blueprint Enhancements
- **Separate timing inputs**: Independent preheat offsets for morning (AM) and evening (PM) peaks
- **Separate action inputs**: Different actions for morning vs evening preheat (e.g., different thermostats, heating strategies)
- **Time-based routing**: Automatically routes to correct AM/PM actions based on peak event start time (<12 for AM, >=12 for PM)

### Docker Testing Support
- Mounted blueprints volume in docker-compose.yml for local testing

## Why This Change?

Users may want different preheat strategies for morning vs evening peaks:
- **Morning peaks**: Longer preheat duration (e.g., 180 minutes) to warm up from overnight setback
- **Evening peaks**: Shorter preheat (e.g., 60 minutes) when house is already warm
- **Different zones**: Control different thermostats/zones for AM vs PM

## Testing

- ✅ Blueprint syntax validated
- ✅ Calendar trigger structure documented in copilot-instructions.md
- ✅ Time-based routing logic verified (< 12 for AM, >= 12 for PM)
- ✅ Docker environment with blueprints mounted for live testing

## Files Changed (3 total)

- `blueprints/winter-credits-calendar.yaml`: Added AM/PM separation
- `blueprints/flex-d-calendar.yaml`: Added AM/PM separation  
- `docker-compose.yml`: Mounted blueprints for testing

## Related Issues

Closes #XX (if applicable)

---

**Note**: This PR contains ONLY blueprint enhancements. The OpenData refactor will come in a separate PR.