### PR TITLE
Correction de l'importation des données historiques

### DIFF
--- a/custom_components/hydroqc/statistics_manager.py
+++ b/custom_components/hydroqc/statistics_manager.py
@@ -323,12 +323,12 @@ class StatisticsManager:
         # Try to find last stat, looking back up to 30 days
         for i in range(30):
             current_date = reference_date - datetime.timedelta(days=i)
-            start_datetime = datetime.datetime.combine(
-                current_date, datetime.time.min
-            ).replace(tzinfo=tz)
-            end_datetime = datetime.datetime.combine(
-                current_date, datetime.time.max
-            ).replace(tzinfo=tz)
+            start_datetime = datetime.datetime.combine(current_date, datetime.time.min).replace(
+                tzinfo=tz
+            )
+            end_datetime = datetime.datetime.combine(current_date, datetime.time.max).replace(
+                tzinfo=tz
+            )
 
             try:
                 last_stats = await get_instance(self.hass).async_add_executor_job(


### PR DESCRIPTION
Correction de bug avec Gemini.  Ceci corrige le problème de la consommation cumulative 731 jours en arrière ainsi que les valeurs qui ne font pas de sens surtout lors des dates de transition entre 2 fichiers CSV.

Commentaires de Gemini:

I will fix this bug by updating the timezone handling logic in consumption_history.py. I'll replace the outdated pytz library with the modern zoneinfo library, which is the standard in Home Assistant. This should resolve the issue with the Daylight Saving Time transition.
I've fixed get_base_sum in statistics_manager.py to prevent data gaps from resetting the cumulative sum, which I believe caused the negative values.
I've fixed _import_statistics in consumption_history.py, confident that the more robust base_sum calculation will resolve the reported issues, especially those appearing on the second sync
I've implemented a fix to block negative consumption values, which I believe will resolve the user's "negative values" complaint.