### PR TITLE
fix(blueprint): use calendar.get_events to detect critical peaks at runtime

### DIFF
--- a/blueprints/winter-credits-calendar.yaml
+++ b/blueprints/winter-credits-calendar.yaml
@@ -352,25 +352,34 @@ condition:
             value_template: "{{ 'Tarif: DCPC' in trigger.calendar_event.description }}"
 variables:
   calendar_entity: !input hydroqc_calendar
-  current_hour: "{{ now().hour }}"
-  # Check if a critical peak event exists for the NEXT peak period
-  # Before 10h: check for morning peak (6h-10h)
-  # From 10h onwards: check for evening peak (16h-20h)
-  # Filters for DCPC tariff to handle multi-tariff calendars
-  next_peak_critical: >
-    {% set events = state_attr(calendar_entity, 'events') | default([]) %}
-    {% set today = now().date() | string %}
-    {% set current_hour = now().hour %}
-    {% set critical_events = events | selectattr('start', 'search', today) | selectattr('summary', 'search', '[Pp]ointe') | selectattr('description', 'search', 'Tarif: DCPC') | list %}
-    {% if current_hour < 10 %}
-      {# Check for morning peak (events starting at 6h) #}
-      {{ critical_events | selectattr('start', 'search', today + 'T06:') | list | length > 0 }}
-    {% else %}
-      {# Check for evening peak (events starting at 16h) #}
-      {{ critical_events | selectattr('start', 'search', today + 'T16:') | list | length > 0 }}
-    {% endif %}
 
 action:
+  # Fetch today's calendar events to determine if peaks are critical or regular
+  - action: calendar.get_events
+    target:
+      entity_id: !input hydroqc_calendar
+    data:
+      start_date_time: "{{ now().replace(hour=0, minute=0, second=0, microsecond=0).isoformat() }}"
+      end_date_time: "{{ now().replace(hour=23, minute=59, second=59, microsecond=0).isoformat() }}"
+    response_variable: calendar_events
+  - variables:
+      # Check if there's a critical morning peak (starting at 6h) today
+      morning_peak_critical: >
+        {{ calendar_events[calendar_entity].events 
+           | selectattr('summary', 'search', '[Pp]ointe')
+           | selectattr('description', 'search', 'Tarif: DCPC')
+           | selectattr('start', 'search', now().strftime('%Y-%m-%dT06:'))
+           | list | length > 0 }}
+      # Check if there's a critical evening peak (starting at 16h) today
+      evening_peak_critical: >
+        {{ calendar_events[calendar_entity].events 
+           | selectattr('summary', 'search', '[Pp]ointe')
+           | selectattr('description', 'search', 'Tarif: DCPC')
+           | selectattr('start', 'search', now().strftime('%Y-%m-%dT16:'))
+           | list | length > 0 }}
+      # Determine which peak is next based on current time
+      next_peak_critical: >
+        {{ morning_peak_critical if now().hour < 10 else evening_peak_critical }}
   - choose:
       # ============================================
       # MORNING ANCHOR START (01:00)


### PR DESCRIPTION
## Description

Fixes critical bug in winter-credits-calendar.yaml blueprint where `state_attr(calendar_entity, 'events')` returns empty, preventing the blueprint from distinguishing between critical and regular peaks.

## Problem

The blueprint released in v0.4.0-beta.1 attempted to use `state_attr(calendar_entity, 'events')` to check for critical peaks. However, the calendar entity's `events` attribute only contains currently active or imminent events (within ~24 hours), not all future events. This made the `next_peak_critical` variable always false, breaking all time-based triggers.

## Solution

Use the `calendar.get_events` service action at runtime to fetch today's events when the automation executes:

```yaml
- action: calendar.get_events
  target:
    entity_id: !input hydroqc_calendar
  data:
    start_date_time: "{{ now().replace(hour=0, minute=0, second=0, microsecond=0).isoformat() }}"
    end_date_time: "{{ now().replace(hour=23, minute=59, second=59, microsecond=0).isoformat() }}"
  response_variable: calendar_events
```

Then filter events to determine critical peaks:
- **Morning peak critical**: Events starting at 6h with "Pointe" summary and "Tarif: DCPC" description
- **Evening peak critical**: Events starting at 16h with "Pointe" summary and "Tarif: DCPC" description
- **Next peak critical**: Based on current hour (morning if before 10h, evening otherwise)

## Benefits

✅ Reliable detection of critical vs regular peaks
✅ Works with both time-based and calendar triggers
✅ No need for input_boolean helpers
✅ Fetches actual calendar data at execution time

## Testing

Tested in Home Assistant developer tools to confirm `calendar.get_events` returns events successfully.

## Related Issues

Fixes the blueprint issue discovered in v0.4.0-beta.1 where time-based triggers could not determine peak criticality.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Code follows project conventions
- [x] Commit message follows Conventional Commits format
- [x] Blueprint tested with runtime event fetching
- [ ] All tests pass (blueprint has no automated tests yet)
