### PR TITLE
fix(blueprint): check current peak criticality instead of next peak

### DIFF
--- a/blueprints/winter-credits-calendar.yaml
+++ b/blueprints/winter-credits-calendar.yaml
@@ -377,9 +377,6 @@ action:
            | selectattr('description', 'search', 'Tarif: DCPC')
            | selectattr('start', 'search', now().strftime('%Y-%m-%dT16:'))
            | list | length > 0 }}
-      # Determine which peak is next based on current time
-      next_peak_critical: >
-        {{ morning_peak_critical if now().hour < 10 else evening_peak_critical }}
   - choose:
       # ============================================
       # MORNING ANCHOR START (01:00)
@@ -388,13 +385,13 @@ action:
           - condition: trigger
             id: anchor_start_morning
           - condition: template
-            value_template: "{{ next_peak_critical }}"
+            value_template: "{{ morning_peak_critical }}"
         sequence: !input critical_anchor_start_morning_action
       - conditions:
           - condition: trigger
             id: anchor_start_morning
           - condition: template
-            value_template: "{{ not next_peak_critical }}"
+            value_template: "{{ not morning_peak_critical }}"
         sequence: !input regular_anchor_start_morning_action
       
       # ============================================
@@ -404,13 +401,13 @@ action:
           - condition: trigger
             id: anchor_end_morning
           - condition: template
-            value_template: "{{ next_peak_critical }}"
+            value_template: "{{ morning_peak_critical }}"
         sequence: !input critical_anchor_end_morning_action
       - conditions:
           - condition: trigger
             id: anchor_end_morning
           - condition: template
-            value_template: "{{ not next_peak_critical }}"
+            value_template: "{{ not morning_peak_critical }}"
         sequence: !input regular_anchor_end_morning_action
       
       # ============================================
@@ -428,13 +425,13 @@ action:
           - condition: trigger
             id: peak_start_morning
           - condition: template
-            value_template: "{{ next_peak_critical }}"
+            value_template: "{{ morning_peak_critical }}"
         sequence: !input critical_peak_start_action
       - conditions:
           - condition: trigger
             id: peak_start_morning
           - condition: template
-            value_template: "{{ not next_peak_critical }}"
+            value_template: "{{ not morning_peak_critical }}"
         sequence: !input regular_peak_start_action
       
       # ============================================
@@ -444,13 +441,13 @@ action:
           - condition: trigger
             id: peak_end_morning
           - condition: template
-            value_template: "{{ next_peak_critical }}"
+            value_template: "{{ morning_peak_critical }}"
         sequence: !input critical_peak_end_action
       - conditions:
           - condition: trigger
             id: peak_end_morning
           - condition: template
-            value_template: "{{ not next_peak_critical }}"
+            value_template: "{{ not morning_peak_critical }}"
         sequence: !input regular_peak_end_action
       
       # ============================================
@@ -460,13 +457,13 @@ action:
           - condition: trigger
             id: anchor_start_evening
           - condition: template
-            value_template: "{{ next_peak_critical }}"
+            value_template: "{{ evening_peak_critical }}"
         sequence: !input critical_anchor_start_evening_action
       - conditions:
           - condition: trigger
             id: anchor_start_evening
           - condition: template
-            value_template: "{{ not next_peak_critical }}"
+            value_template: "{{ not evening_peak_critical }}"
         sequence: !input regular_anchor_start_evening_action
       
       # ============================================
@@ -476,13 +473,13 @@ action:
           - condition: trigger
             id: anchor_end_evening
           - condition: template
-            value_template: "{{ next_peak_critical }}"
+            value_template: "{{ evening_peak_critical }}"
         sequence: !input critical_anchor_end_evening_action
       - conditions:
           - condition: trigger
             id: anchor_end_evening
           - condition: template
-            value_template: "{{ not next_peak_critical }}"
+            value_template: "{{ not evening_peak_critical }}"
         sequence: !input regular_anchor_end_evening_action
       
       # ============================================
@@ -500,13 +497,13 @@ action:
           - condition: trigger
             id: peak_start_evening
           - condition: template
-            value_template: "{{ next_peak_critical }}"
+            value_template: "{{ evening_peak_critical }}"
         sequence: !input critical_peak_start_action
       - conditions:
           - condition: trigger
             id: peak_start_evening
           - condition: template
-            value_template: "{{ not next_peak_critical }}"
+            value_template: "{{ not evening_peak_critical }}"
         sequence: !input regular_peak_start_action
       
       # ============================================
@@ -516,12 +513,12 @@ action:
           - condition: trigger
             id: peak_end_evening
           - condition: template
-            value_template: "{{ next_peak_critical }}"
+            value_template: "{{ evening_peak_critical }}"
         sequence: !input critical_peak_end_action
       - conditions:
           - condition: trigger
             id: peak_end_evening
           - condition: template
-            value_template: "{{ not next_peak_critical }}"
+            value_template: "{{ not evening_peak_critical }}"
         sequence: !input regular_peak_end_action
 


### PR DESCRIPTION
## Problem

The Winter Credits (CPC-D) blueprint was incorrectly evaluating peak criticality for end-of-peak triggers. When the morning peak ended at 10:00, it would check if the **evening** peak was critical instead of checking if the **morning** peak that just ended was critical.

**Example scenario:**
- Morning peak: regular (no calendar event)
- Evening peak: critical (calendar event exists)
- At 10:00 (end of morning peak): ❌ Executed critical peak end actions instead of regular peak end actions

## Root Cause

The `next_peak_critical` variable used `now().hour < 10` to determine which peak to check:
- Before 10:00 → check morning peak ✅
- At/after 10:00 → check evening peak ❌ (wrong for morning peak end at 10:00)

## Solution

Removed the `next_peak_critical` variable and made each trigger explicitly check the appropriate peak:
- **Morning triggers** (01:00, 04:00, 06:00, 10:00) → check `morning_peak_critical`
- **Evening triggers** (12:00, 14:00, 16:00, 20:00) → check `evening_peak_critical`

## Testing

Verified that anchor functionality is preserved:
- Morning anchors (01:00-04:00) correctly prepare for morning peak
- Evening anchors (12:00-14:00) correctly prepare for evening peak

## Impact

This fix ensures that:
- ✅ Peak end actions match the peak that just ended (not the next one)
- ✅ Anchors correctly reflect the criticality of the peak they're preparing for
- ✅ Mixed scenarios work correctly (regular morning + critical evening, or vice versa)