### PR TITLE
fix(blueprints): prevent preheat trigger conflicts for both morning and evening peaks

### DIFF
--- a/blueprints/winter-credits-calendar.yaml
+++ b/blueprints/winter-credits-calendar.yaml
@@ -416,6 +416,8 @@ action:
       - conditions:
           - condition: trigger
             id: preheat_morning
+          - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int < 12 }}"
         sequence: !input critical_preheat_morning_action
       
       # ============================================
@@ -488,6 +490,8 @@ action:
       - conditions:
           - condition: trigger
             id: preheat_evening
+          - condition: template
+            value_template: "{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int >= 12 }}"
         sequence: !input critical_preheat_evening_action
       
       # ============================================


### PR DESCRIPTION
## Problem

Users reported that evening preheat actions were being triggered during morning peak events. The root cause was that both calendar triggers (`preheat_morning` and `preheat_evening`) were listening to the same calendar entity for **any** peak event start, without checking which peak time the event was for.

This meant:
- **Morning peak (6h)** would trigger BOTH morning and evening preheat handlers
- **Evening peak (16h)** would trigger BOTH morning and evening preheat handlers

## Solution

Added hour-based filtering to differentiate between morning and evening peaks:
- **Morning preheat**: Only triggers if event starts before 12:00 (`hour < 12`)
- **Evening preheat**: Only triggers if event starts at or after 12:00 (`hour >= 12`)

## Changes

### Winter Credits Blueprint (`winter-credits-calendar.yaml`)
- Added time check to `preheat_morning` handler: `{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int < 12 }}`
- Added time check to `preheat_evening` handler: `{{ as_timestamp(trigger.calendar_event.start) | timestamp_custom('%H') | int >= 12 }}`

### Flex-D Blueprint (`flex-d-calendar.yaml`)
- No functional changes (already had correct hour-based filtering)

## Testing

- ✅ Blueprint YAML syntax validated
- ✅ Logic verified: morning events (6h) only trigger morning preheat, evening events (16h) only trigger evening preheat
- ✅ Maintains compatibility with existing automations

## Related Issues

Fixes user-reported issue about evening preheat notifications during morning peaks.